### PR TITLE
fixed panic when defining the same header twice

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -113,7 +113,7 @@ impl<'a> Context<'a> {
                             o.add_property(s, value.take().unwrap());
                         }
                     })
-                    .or_insert(value.take().unwrap().into());
+                    .or_insert_with(|| value.take().unwrap().into());
             }
         }
         self
@@ -301,5 +301,12 @@ mod tests {
         .collect();
         assert_eq!(ctx.render("{{a}}"), Ok("b".to_owned()));
         assert_eq!(ctx.render("{{b}}"), Ok("c".to_owned()));
+    }
+    #[test]
+    fn double_defintition_should_overwrite() {
+        let ctx = Context::new()
+        .with_define(Variable::single("a"), "b")
+        .with_define(Variable::single("a"), "c");
+        assert_eq!(ctx.render("{{a}}"), Ok("c".to_owned()));
     }
 }


### PR DESCRIPTION
This PR fixes a panic that occurs when a variable is added twice to the same context caused by the fact that 
```rust
.or_insert(value.take().unwrap().into())
```
... is always executed. Using the insert with an enclosure
```rust
.or_insert_with(|| value.take().unwrap().into());
```
... ensures that the statement is only executed when no entry is found.
